### PR TITLE
feat: upgrade Codecov action to v5 for coverage report upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: 📦 Upload Coverage Report
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
This pull request updates the configuration for uploading coverage reports in the GitHub Actions workflow. The main change is upgrading the Codecov action to a newer version and adding a required token for authentication.

Continuous integration workflow update:

* Upgraded the Codecov GitHub Action from version 4 to version 5 in `.github/workflows/tests.yml`, and added the `CODECOV_TOKEN` secret to the upload step to ensure proper authentication.